### PR TITLE
Updates RSpec matchers to use ExecJS

### DIFF
--- a/couch_potato-rspec.gemspec
+++ b/couch_potato-rspec.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
 
   s.add_dependency 'rspec', '~>3.0'
+  s.add_dependency 'execjs'
   s.add_development_dependency 'rake'
 
   s.files         = `git ls-files | grep "lib/couch_potato/rspec\|vendor/pouchdb-collate"`.split("\n")

--- a/couch_potato.gemspec
+++ b/couch_potato.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'timecop'
   s.add_development_dependency 'tzinfo'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'execjs'
 
   s.files         = `git ls-files | grep -v "lib/couch_potato/rspec"`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/* | grep -v rspec_matchers`.split("\n")

--- a/lib/couch_potato/rspec/matchers.rb
+++ b/lib/couch_potato/rspec/matchers.rb
@@ -1,11 +1,7 @@
 begin
-  require 'v8'
+  require 'execjs'
 rescue LoadError
-  begin
-    require 'rhino'
-  rescue LoadError
-    STDERR.puts "You need to install therubyracer (or therhinoracer on jruby) to use matchers"
-  end
+  STDERR.puts "You need to install execjs to use matchers"
 end
 
 module CouchPotato
@@ -14,11 +10,7 @@ module CouchPotato
       private
 
       def run_js(js)
-        if defined?(V8)
-          V8::Context.new.eval(js)
-        else
-          Rhino::Context.open{|cxt| cxt.eval(js)}
-        end
+        ExecJS.exec(js)
       end
     end
   end

--- a/lib/couch_potato/rspec/matchers/list_as_matcher.rb
+++ b/lib/couch_potato/rspec/matchers/list_as_matcher.rb
@@ -32,7 +32,7 @@ module CouchPotato
             listed = listed + text;
           };
           list();
-          JSON.stringify(JSON.parse(listed));
+          return JSON.stringify(JSON.parse(listed));
         JS
 
         @actual_ruby = JSON.parse(run_js(js))

--- a/lib/couch_potato/rspec/matchers/map_reduce_to_matcher.rb
+++ b/lib/couch_potato/rspec/matchers/map_reduce_to_matcher.rb
@@ -184,7 +184,7 @@ module CouchPotato
             results.push({key: group.groupedKey, value: reduced});
           }
 
-          JSON.stringify(results);
+          return JSON.stringify(results);
         JS
         @actual_ruby = JSON.parse(run_js(js))
         @expected_ruby == @actual_ruby

--- a/lib/couch_potato/rspec/matchers/map_to_matcher.rb
+++ b/lib/couch_potato/rspec/matchers/map_to_matcher.rb
@@ -43,7 +43,7 @@ module CouchPotato
             result.push([key, value]);
           };
           map(doc);
-          JSON.stringify(result);
+          return JSON.stringify(result);
         JS
         @actual_ruby = JSON.parse(run_js(js))
         @expected_ruby == @actual_ruby

--- a/lib/couch_potato/rspec/matchers/reduce_to_matcher.rb
+++ b/lib/couch_potato/rspec/matchers/reduce_to_matcher.rb
@@ -30,7 +30,7 @@ module CouchPotato
           var keys = #{@keys.to_json};
           var values = #{@values.to_json};
           var reduce = #{view_spec.reduce_function};
-          JSON.stringify({result: reduce(keys, values, #{@rereduce})});
+          return JSON.stringify({result: reduce(keys, values, #{@rereduce})});
         JS
         @actual_ruby = JSON.parse(run_js(js))['result']
         @expected_ruby == @actual_ruby


### PR DESCRIPTION
This commit deprecates v8 and Rhino dependencies in favor of ExecJS
which can use various backends.